### PR TITLE
Minor cleanup of depreactions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        kotlin_version = "1.3.50"
+        kotlin_version = "1.4.10"
     }
     repositories {
         mavenCentral()

--- a/lib/src/main/kotlin/se/gustavkarlsson/koptional/Creation.kt
+++ b/lib/src/main/kotlin/se/gustavkarlsson/koptional/Creation.kt
@@ -1,8 +1,5 @@
 package se.gustavkarlsson.koptional
 
-@Deprecated("Useless", ReplaceWith("Absent"), DeprecationLevel.ERROR)
-fun <T : Any> absent(): Optional<T> = Absent
-
 fun <T : Any> optionalOf(value: T?): Optional<T> = if (value == null) Absent else Present(value)
 
 fun <T : Any> T?.toOptional(): Optional<T> = optionalOf(this)

--- a/lib/src/main/kotlin/se/gustavkarlsson/koptional/Optional.kt
+++ b/lib/src/main/kotlin/se/gustavkarlsson/koptional/Optional.kt
@@ -4,6 +4,7 @@ sealed class Optional<out T : Any> {
 
     abstract val value: T?
 
+    @Deprecated(message = "Unsafe to use. Use `ifPresent` or `ifAbsent` instead")
     abstract val valueUnsafe: T
 
     abstract val isPresent: Boolean

--- a/lib/src/main/kotlin/se/gustavkarlsson/koptional/Optional.kt
+++ b/lib/src/main/kotlin/se/gustavkarlsson/koptional/Optional.kt
@@ -5,7 +5,7 @@ sealed class Optional<out T : Any> {
     abstract val value: T?
 
     @Deprecated(
-        message = "Useless"
+        message = "Useless",
         replaceWith = ReplaceWith("value!!")
     )
     abstract val valueUnsafe: T

--- a/lib/src/main/kotlin/se/gustavkarlsson/koptional/Optional.kt
+++ b/lib/src/main/kotlin/se/gustavkarlsson/koptional/Optional.kt
@@ -4,7 +4,10 @@ sealed class Optional<out T : Any> {
 
     abstract val value: T?
 
-    @Deprecated(message = "Unsafe to use. Use `ifPresent` or `ifAbsent` instead")
+    @Deprecated(
+        message = "Useless"
+        replaceWith = ReplaceWith("value!!")
+    )
     abstract val valueUnsafe: T
 
     abstract val isPresent: Boolean


### PR DESCRIPTION
As discussed in #2 `valueUnsafe` shouldn't be used. 
There are better functions for them.

Beside of that I removed an 1 year old deprecated function. I think this is okay 😇 